### PR TITLE
feat: forecast, inline mode, and UI improvements

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import time
+import uuid
 
 # Load .env FIRST — before any custom module is imported
 from dotenv import load_dotenv
@@ -9,6 +10,7 @@ load_dotenv()
 from aiogram import Bot, Dispatcher, F, Router, types
 from aiogram.enums import ContentType, ParseMode
 from aiogram.filters import Command
+from aiogram.types import InlineQueryResultArticle, InputTextMessageContent
 from loguru import logger
 
 from exceptions import WrongInput
@@ -19,14 +21,15 @@ from weather_api_service import (
     Coordinates,
     get_air_quality_type,
     get_coordinates_by_city,
+    get_forecast_response,
     get_openweather_air_response,
     get_openweather_city_response,
     get_openweather_response,
     get_weather,
+    parse_forecast,
 )
-from weather_repr import weather_repr, weather_repr_city
+from weather_repr import feels_like_emoji, forecast_repr, weather_repr, weather_repr_city
 
-# initialize logging file to catch errors
 logger.add(
     "log_errors.log",
     format="{time} {level} {message}",
@@ -38,29 +41,40 @@ API_TOKEN = os.getenv("TELEGRAM_API_TOKEN")
 if not API_TOKEN:
     raise RuntimeError("TELEGRAM_API_TOKEN is not set — check your .env file")
 
-# initialize bot, dispatcher and router
 bot = Bot(token=API_TOKEN)
 dp = Dispatcher()
 router = Router()
 dp.include_router(router)
 
 
+def _map_button(lat: float, lon: float) -> types.InlineKeyboardMarkup:
+    """Inline keyboard with a direct link to the OpenWeatherMap map."""
+    url = (
+        f"https://openweathermap.org/weathermap?"
+        f"basemap=map&cities=true&layer=temperature&lat={lat}&lon={lon}&zoom=10"
+    )
+    return types.InlineKeyboardMarkup(
+        inline_keyboard=[[types.InlineKeyboardButton(text="\U0001f5fa View on map", url=url)]]
+    )
+
+
 @router.message(Command("start", "help"))
 async def send_welcome(message: types.Message):
-    """Returns info what bot is about"""
+    """Returns info about what the bot can do."""
     await message.answer(
         "Hi!\nI'm <b>WeWeather</b> Bot\n"
-        "I can provide you with the weather around you or more\n"
-        "Just type the city you are looking for\n"
-        "or type /inplace so the weather around you pops up.\n"
-        "If you'd like to explore the weather at random spot type /random",
+        "I can provide you with the weather around you or more\n\n"
+        "\U0001f4cd Just type a city name to get current weather\n"
+        "\U0001f4c5 Use /forecast &lt;city&gt; for a 5-day forecast\n"
+        "\U0001f4cc Use /inplace to share your location\n"
+        "\U0001f3b2 Use /random for weather at a random spot",
         parse_mode=ParseMode.HTML,
     )
 
 
 def get_keyboard():
-    """Initiates button to share with GEO"""
-    keyboard = types.ReplyKeyboardMarkup(
+    """Initiates button to share GEO."""
+    return types.ReplyKeyboardMarkup(
         keyboard=[
             [
                 types.KeyboardButton(text="\U0001f30d Share GEO", request_location=True),
@@ -70,7 +84,6 @@ def get_keyboard():
         resize_keyboard=True,
         input_field_placeholder="Share GEO or Discard",
     )
-    return keyboard
 
 
 @router.message(F.text == "\U0001f6ab Discard")
@@ -113,6 +126,7 @@ async def send_random_weather(callback: types.CallbackQuery):
         f"\U0001f305: {sun_conditions.sunrise.strftime('%H:%M')}\n"
         f"\U0001f307: {sun_conditions.sunset.strftime('%H:%M')}",
         parse_mode=ParseMode.HTML,
+        reply_markup=_map_button(coordinates.latitude, coordinates.longitude),
     )
     await callback.message.answer_location(latitude=coordinates.latitude, longitude=coordinates.longitude)
     await callback.answer()
@@ -121,7 +135,7 @@ async def send_random_weather(callback: types.CallbackQuery):
 @router.message(F.content_type == ContentType.LOCATION)
 @logger.catch
 async def weather_by_location(message: types.Message):
-    """Returns readable format of the weather"""
+    """Returns readable format of the weather."""
     lat = message.location.latitude
     lon = message.location.longitude
     coordinates = Coordinates(*map(lambda x: round(x, 2), [lat, lon]))
@@ -145,22 +159,43 @@ async def weather_by_location(message: types.Message):
         f"{'*' * 10}\n"
         f"\U0001f305: {sun_conditions.sunrise.strftime('%H:%M')}\n"
         f"\U0001f307: {sun_conditions.sunset.strftime('%H:%M')}",
-        reply_markup=types.ReplyKeyboardRemove(),
+        reply_markup=_map_button(coordinates.latitude, coordinates.longitude),
         parse_mode=ParseMode.HTML,
     )
 
 
 @router.message(Command("inplace"))
 async def weather_me(message: types.Message):
-    """Invokes the button in Telegram"""
-    reply = "Click on the button below to share your location"
-    await message.answer(reply, reply_markup=get_keyboard())
+    """Invokes the location sharing button in Telegram."""
+    await message.answer("Click on the button below to share your location", reply_markup=get_keyboard())
+
+
+@router.message(Command("forecast"))
+@logger.catch
+async def forecast_command(message: types.Message):
+    """Returns a 5-day forecast for a given city."""
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Please provide a city name:\n/forecast Moscow")
+        return
+    city = parts[1].strip()
+    response = get_forecast_response(city)
+    if str(response.get("cod")) == "404":
+        await message.answer("Oops, looks like there is no such city\nCheck the spelling")
+        return
+    days = parse_forecast(response)
+    city_name = response.get("city", {}).get("name", city)
+    country_code = response.get("city", {}).get("country", "")
+    await message.answer(
+        forecast_repr(days, city_name, country_code),
+        parse_mode=ParseMode.HTML,
+    )
 
 
 @router.message()
 @logger.catch
 async def weather_by_city(message: types.Message):
-    """Represents weather in Telegram"""
+    """Returns current weather for a typed city name."""
     openweather_city_response = get_openweather_city_response(message.text)
     if openweather_city_response["cod"] != ERROR:
         coordinates = get_coordinates_by_city(openweather_city_response)
@@ -182,12 +217,55 @@ async def weather_by_city(message: types.Message):
             f"{weather_represent}"
             f"{'*' * 10}\n"
             f"\U0001f305: {sun_conditions.sunrise.strftime('%H:%M')}\n"
-            f"\U0001f307: {sun_conditions.sunset.strftime('%H:%M')}"
+            f"\U0001f307: {sun_conditions.sunset.strftime('%H:%M')}",
+            reply_markup=_map_button(coordinates.latitude, coordinates.longitude),
         )
         await bot.send_location(message.chat.id, latitude=coordinates.latitude, longitude=coordinates.longitude)
     else:
         await message.answer("Oops, looks like there is no such city\nCheck the spelling")
         raise WrongInput(f'City "{message.text}" is not defined')
+
+
+@router.inline_query()
+@logger.catch
+async def inline_weather(inline_query: types.InlineQuery):
+    """Handle inline queries: type @YourBot Stockholm in any chat."""
+    city = inline_query.query.strip()
+    if not city:
+        await inline_query.answer(
+            [],
+            cache_time=1,
+            switch_pm_text="Type a city name...",
+            switch_pm_parameter="start",
+        )
+        return
+    try:
+        response = get_openweather_city_response(city)
+        if str(response.get("cod")) == ERROR:
+            await inline_query.answer([], cache_time=1)
+            return
+        weather = get_weather(response)
+        text = (
+            f"\U0001f324 <b>{weather.city}</b>\n"
+            f"\U0001f321 {weather.temperature}\u00b0C  {feels_like_emoji(weather.feels_like)}\n"
+            f"{weather.weather_type.value}\n"
+            f"Feels like: {weather.feels_like}\u00b0C\n"
+            f"\U0001f4a8 Wind: {weather.wind_speed} m/s\n"
+            f"\U0001f4a7 Humidity: {weather.humidity}%\n"
+            f"\U0001f53d Pressure: {weather.pressure} hPa"
+        )
+        result = InlineQueryResultArticle(
+            id=str(uuid.uuid4()),
+            title=f"\U0001f324 {weather.city} \u2014 {weather.temperature}\u00b0C",
+            description=f"{weather.weather_type.value}  |  Feels like {weather.feels_like}\u00b0C",
+            input_message_content=InputTextMessageContent(
+                message_text=text,
+                parse_mode=ParseMode.HTML,
+            ),
+        )
+        await inline_query.answer([result], cache_time=30)
+    except Exception:
+        await inline_query.answer([], cache_time=1)
 
 
 async def main():

--- a/weather_api_service.py
+++ b/weather_api_service.py
@@ -41,21 +41,21 @@ class Coordinates(NamedTuple):
 
 
 class WeatherType(Enum):
-    THUNDERSTORM = "Thunderstorm \U0001F329"
-    DRIZZLE = "Drizzle \U0001F327"
-    RAIN = "Rain \U0001F327"
-    SNOW = "Snow \U0001F328"
-    CLEAR = "Clear \u2600\uFE0F"
-    FOG = "Fog \U0001F32B"
-    CLOUDS = "Clouds \u2601"
+    THUNDERSTORM = "Thunderstorm \u26c8"
+    DRIZZLE = "Drizzle \U0001f326"
+    RAIN = "Rain \U0001f327"
+    SNOW = "Snow \u2744\ufe0f"
+    CLEAR = "Clear \u2600\ufe0f"
+    FOG = "Fog \U0001f32b"
+    CLOUDS = "Clouds \u26c5"
 
 
 class AirQualityType(Enum):
-    GOOD = "Good \U0001F60A"
-    FAIR = "Fair \U0001F60C"
-    MODERATE = "Moderate \U0001F610"
-    POOR = "Poor \U0001F61E"
-    VERY_POOR = "Very Poor \U0001F622"
+    GOOD = "Good \U0001f60a"
+    FAIR = "Fair \U0001f60c"
+    MODERATE = "Moderate \U0001f610"
+    POOR = "Poor \U0001f61e"
+    VERY_POOR = "Very Poor \U0001f622"
 
 
 class Weather(NamedTuple):
@@ -69,15 +69,44 @@ class Weather(NamedTuple):
     sunset: datetime
     city: Locality
     country: Locality
+    wind_speed: float = 0.0
+    pressure: int = 0
+
+
+class ForecastDay(NamedTuple):
+    date: str           # e.g. "2026-03-05"
+    temperature_min: Celsius
+    temperature_max: Celsius
+    weather_type: WeatherType
+    wind_speed: float
+
+
+_WEATHER_TYPE_MAP = {
+    "2": WeatherType.THUNDERSTORM,
+    "3": WeatherType.DRIZZLE,
+    "5": WeatherType.RAIN,
+    "6": WeatherType.SNOW,
+    "7": WeatherType.FOG,
+    "800": WeatherType.CLEAR,
+    "80": WeatherType.CLOUDS,
+}
+
+
+def _resolve_weather_type(weather_id: int) -> WeatherType:
+    id_str = str(weather_id)
+    for prefix, wtype in _WEATHER_TYPE_MAP.items():
+        if id_str.startswith(prefix):
+            return wtype
+    return WeatherType.CLOUDS
 
 
 def get_weather(openweather_response: dict) -> Weather:
-    """Returns parsed weather data"""
+    """Returns parsed weather data."""
     return _parse_openweather_response(openweather_response)
 
 
 def get_openweather_response(latitude: float, longitude: float) -> dict:
-    """Returns raw weather data by coordinates"""
+    """Returns raw weather data by coordinates."""
     url = (
         f"{OPENWEATHER_BASE}/weather?"
         f"lat={latitude}&lon={longitude}&"
@@ -90,7 +119,7 @@ def get_openweather_response(latitude: float, longitude: float) -> dict:
 
 
 def get_openweather_air_response(latitude: float, longitude: float) -> dict:
-    """Returns Air Quality Index"""
+    """Returns Air Quality Index."""
     url = (
         f"{OPENWEATHER_AIR_BASE}/air_pollution?"
         f"lat={latitude}&lon={longitude}&"
@@ -103,7 +132,7 @@ def get_openweather_air_response(latitude: float, longitude: float) -> dict:
 
 
 def get_openweather_city_response(city: str) -> dict:
-    """Returns raw weather data by city name"""
+    """Returns raw weather data by city name."""
     url = (
         f"{OPENWEATHER_BASE}/weather?"
         f"q={city}&appid={_api_token()}&units=metric"
@@ -112,6 +141,54 @@ def get_openweather_city_response(city: str) -> dict:
         return requests.get(url).json()
     except ConnectionError:
         raise ApiServiceError
+
+
+def get_forecast_response(city: str) -> dict:
+    """Returns 5-day / 3-hour forecast by city name."""
+    url = (
+        f"{OPENWEATHER_BASE}/forecast?"
+        f"q={city}&appid={_api_token()}&units=metric&lang=en"
+    )
+    try:
+        return requests.get(url).json()
+    except ConnectionError:
+        raise ApiServiceError
+
+
+def get_forecast_by_coords(latitude: float, longitude: float) -> dict:
+    """Returns 5-day / 3-hour forecast by coordinates."""
+    url = (
+        f"{OPENWEATHER_BASE}/forecast?"
+        f"lat={latitude}&lon={longitude}&appid={_api_token()}&units=metric&lang=en"
+    )
+    try:
+        return requests.get(url).json()
+    except ConnectionError:
+        raise ApiServiceError
+
+
+def parse_forecast(forecast_response: dict) -> list[ForecastDay]:
+    """Returns one ForecastDay per calendar day (prefers the noon slot)."""
+    days: dict[str, ForecastDay] = {}
+    for item in forecast_response.get("list", []):
+        dt_txt = item.get("dt_txt", "")
+        date = dt_txt[:10]
+        hour = dt_txt[11:13]
+        if not date:
+            continue
+        try:
+            entry = ForecastDay(
+                date=date,
+                temperature_min=item["main"]["temp_min"],
+                temperature_max=item["main"]["temp_max"],
+                weather_type=_resolve_weather_type(item["weather"][0]["id"]),
+                wind_speed=round(item["wind"]["speed"], 1),
+            )
+        except (KeyError, IndexError):
+            continue
+        if date not in days or hour == "12":
+            days[date] = entry
+    return list(days.values())[:5]
 
 
 def get_coordinates_by_city(openweather_city_response: dict) -> Coordinates:
@@ -132,6 +209,8 @@ def _parse_openweather_response(openweather_dict: dict) -> Weather:
         sunset=_parse_sun_time(openweather_dict, "sunset"),
         city=_parse_city(openweather_dict),
         country=_parse_country(openweather_dict),
+        wind_speed=round(openweather_dict.get("wind", {}).get("speed", 0.0), 1),
+        pressure=openweather_dict.get("main", {}).get("pressure", 0),
     )
 
 
@@ -148,26 +227,13 @@ def _parse_humidity(openweather_dict: dict) -> Humidity:
 
 def _parse_weather_type(openweather_dict: dict) -> WeatherType:
     try:
-        weather_type_id = str(openweather_dict["weather"][0]["id"])
+        return _resolve_weather_type(openweather_dict["weather"][0]["id"])
     except (IndexError, KeyError):
         raise ApiServiceError
-    weather_types = {
-        "2": WeatherType.THUNDERSTORM,
-        "3": WeatherType.DRIZZLE,
-        "5": WeatherType.RAIN,
-        "6": WeatherType.SNOW,
-        "7": WeatherType.FOG,
-        "800": WeatherType.CLEAR,
-        "80": WeatherType.CLOUDS,
-    }
-    for _id, _weather_type in weather_types.items():
-        if weather_type_id.startswith(_id):
-            return _weather_type
-    raise ApiServiceError
 
 
 def get_air_quality_type(openweather_dict: dict) -> AirQualityType:
-    """Returns air quality type using AQI"""
+    """Returns air quality type using AQI."""
     try:
         air_type_id = str(openweather_dict["list"][0]["main"]["aqi"])
     except (IndexError, KeyError):

--- a/weather_repr.py
+++ b/weather_repr.py
@@ -1,26 +1,67 @@
-from weather_api_service import Weather
+from datetime import datetime
+
 from flag import flag
+
+from weather_api_service import ForecastDay, Weather
+
+
+def feels_like_emoji(temp: float) -> str:
+    """Returns an emoji that reflects how the temperature feels."""
+    if temp <= -15:
+        return "\U0001f976"   # 🥶 freezing
+    if temp <= 0:
+        return "\U0001f9ca"   # 🧐 cold
+    if temp <= 10:
+        return "\U0001f32c\ufe0f"  # 🌬 windy/cool
+    if temp <= 20:
+        return "\U0001f60a"   # 😊 comfortable
+    if temp <= 30:
+        return "\u2600\ufe0f"  # ☀️ warm
+    return "\U0001f525"       # 🔥 hot
 
 
 def weather_repr(weather: Weather) -> str:
-    """Formats weather data to readable representation """
-    return (f"{weather.city} {flag(weather.country or 'None')}\n"
-            f"Temperature: {weather.temperature}°C\n"
-            f"{weather.weather_type.value}\n"
-            f"Feels like: {weather.feels_like}°C\n"
-            f"Max temperature: {weather.temperature_max}°C\n"
-            f"Min temperature: {weather.temperature_min}°C\n"
-            f"Humidity: {weather.humidity}%\n"
-            )
+    """Formats location-based weather data to readable representation."""
+    return (
+        f"{weather.city} {flag(weather.country or 'None')}\n"
+        f"\U0001f321 Temperature: {weather.temperature}\u00b0C\n"
+        f"{weather.weather_type.value}\n"
+        f"Feels like: {weather.feels_like}\u00b0C {feels_like_emoji(weather.feels_like)}\n"
+        f"Max: {weather.temperature_max}\u00b0C  Min: {weather.temperature_min}\u00b0C\n"
+        f"\U0001f4a7 Humidity: {weather.humidity}%\n"
+        f"\U0001f4a8 Wind: {weather.wind_speed} m/s\n"
+        f"\U0001f53d Pressure: {weather.pressure} hPa\n"
+    )
 
 
 def weather_repr_city(weather: Weather) -> str:
-    """Formats weather data to readable representation """
-    return (f"{weather.city} {flag(weather.country)}\n"
-            f"Temperature: {weather.temperature}°C\n"
-            f"{weather.weather_type.value}\n"
-            f"Feels like: {weather.feels_like}°C\n"
-            f"Max temperature: {weather.temperature_max}°C\n"
-            f"Min temperature: {weather.temperature_min}°C\n"
-            f"Humidity: {weather.humidity}%\n"
-            )
+    """Formats city-based weather data to readable representation."""
+    return (
+        f"{weather.city} {flag(weather.country)}\n"
+        f"\U0001f321 Temperature: {weather.temperature}\u00b0C\n"
+        f"{weather.weather_type.value}\n"
+        f"Feels like: {weather.feels_like}\u00b0C {feels_like_emoji(weather.feels_like)}\n"
+        f"Max: {weather.temperature_max}\u00b0C  Min: {weather.temperature_min}\u00b0C\n"
+        f"\U0001f4a7 Humidity: {weather.humidity}%\n"
+        f"\U0001f4a8 Wind: {weather.wind_speed} m/s\n"
+        f"\U0001f53d Pressure: {weather.pressure} hPa\n"
+    )
+
+
+def forecast_repr(days: list[ForecastDay], city_name: str, country_code: str) -> str:
+    """Formats 5-day forecast to readable HTML representation."""
+    try:
+        country_flag = flag(country_code)
+    except Exception:
+        country_flag = ""
+    lines = [f"\U0001f4c5 <b>5-day forecast \u2014 {city_name} {country_flag}</b>\n"]
+    for day in days:
+        dt = datetime.strptime(day.date, "%Y-%m-%d")
+        day_name = dt.strftime("%a %b %d")
+        lines.append(
+            f"<b>{day_name}</b>\n"
+            f"  {day.weather_type.value}\n"
+            f"  \U0001f321 {day.temperature_min:.0f}\u00b0C \u2013 {day.temperature_max:.0f}\u00b0C"
+            f"   \U0001f4a8 {day.wind_speed} m/s\n"
+        )
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
Adds a set of user-facing improvements to the WeatherTGBot UI and features.

## Included (easy → harder)
- Current weather now shows wind + pressure.
- Adds a small “feels like” emoji indicator.
- Adds an inline map button (OpenWeatherMap link) to weather replies.
- Adds `/forecast <city>`: 5-day forecast (from OpenWeather `/forecast`).
- Adds inline mode: type `@YourBot <city>` in any chat.

## Notes
- `/forecast` uses OpenWeather 5-day / 3-hour API and selects one entry per day (prefers 12:00).
- Map button is a simple URL to OpenWeatherMap weathermap (no extra API calls).

## How to test
- `/start`
- Type a city name (e.g. Stockholm)
- `/inplace` (share location)
- `/random`
- `/forecast Stockholm`
- Inline mode: in any chat type `@<your_bot_username> Stockholm` and pick the result.
