### PR TITLE
feat: daily weather subscription + updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,90 @@
 
 <img src="weather.png" style="height: 100px; width:100px"/>
 
+A Telegram weather bot powered by [OpenWeather API](https://openweathermap.org/api) and built with [aiogram 3](https://docs.aiogram.dev/).
 
-This bot utilizes your GPS coordinates/ or city /or even a random spot to show the weather conditions and more using [OpenWeather](https://openweathermap.org/api)
+Try it live: **[@NeedWeatherInPlaceBot](https://t.me/NeedWeatherInPlaceBot)**
 
-To run the bot install all necessary packages
+## Features
+
+- 🌡 **Current weather** by city name or GPS location
+- 📅 **5-day forecast** with daily breakdown
+- 💨 Wind speed, 🔽 pressure, 💧 humidity included in every response
+- 🗺 **Map link** to OpenWeatherMap for every weather result
+- 🎲 **Random weather** — discover weather anywhere on Earth
+- ❤️ **Favourite cities** — save up to 3 cities for one-tap access
+- ⏰ **Daily subscription** — receive weather every day at your chosen local time
+- 🔍 **Inline mode** — share weather in any chat by typing `@NeedWeatherInPlaceBot <city>`
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `<city name>` | Current weather for any city |
+| `/inplace` | Share GPS location for local weather |
+| `/forecast <city>` | 5-day forecast |
+| `/random` | Weather at a random location |
+| `/save <city>` | Save a city to favourites (max 3) |
+| `/my` | Show saved cities as tappable buttons |
+| `/remove <city>` | Remove a city from favourites |
+| `/subscribe <city> <HH:MM>` | Daily weather at a set local time |
+| `/unsubscribe` | Cancel daily subscription |
+| `/mysub` | Show current subscription |
+
+## Setup
+
+### 1. Clone and install
 
 ```bash
+git clone https://github.com/maki198906/WeatherTGBot.git
+cd WeatherTGBot
 pip install -r requirements.txt
 ```
-Obtain your own OpenWeather/Telegram API Tokens:
 
-`OPEN_WEATHER_API_TOKEN`
+### 2. Create `.env`
 
-`TELEGRAM_API_TOKEN`
+```env
+TELEGRAM_API_TOKEN=your_telegram_bot_token
+OPEN_WEATHER_API_TOKEN=your_openweather_api_key
+```
 
-Then execute ```server.py```
+- **Telegram token**: message [@BotFather](https://t.me/BotFather) → `/newbot`
+- **OpenWeather key**: [openweathermap.org/api](https://openweathermap.org/api) (free tier is sufficient)
+
+### 3. Run
 
 ```bash
 python server.py
 ```
 
-This Bot supports Docker:
+The bot creates `favourites.db` (SQLite) automatically on first run — no database setup needed.
 
-In order to launch Bot run commands as follows:
+## Docker
+
 ```bash
-docker build -t tgweather \
---build-arg TELEGRAM=$TELEGRAM_API_TOKEN \
---build-arg OPEN_WEATHER=$OPEN_WEATHER_API_TOKEN \
---no-cache ./
+docker build -t tgweather .
 
-docker run -d --name tgbot tgweather
+docker run -d --name tgbot \
+  -e TELEGRAM_API_TOKEN=your_token \
+  -e OPEN_WEATHER_API_TOKEN=your_token \
+  tgweather
 ```
-**NOTE:** First make sure having `OPEN_WEATHER_API_TOKEN` and `TELEGRAM_API_TOKEN` in your environment
 
-You can check out how it works finding **@NeedWeatherInPlaceBot** in Telegram
+## Project Structure
+
+```
+WeatherTGBot/
+├── server.py               # Bot entry point — all handlers
+├── weather_api_service.py  # OpenWeather API calls and data models
+├── weather_repr.py         # Weather data → readable text
+├── favourites.py           # Favourite cities (SQLite)
+├── subscriptions.py        # Daily subscriptions (SQLite)
+├── scheduler.py            # APScheduler — background daily jobs
+├── timezoneutils.py        # Sunrise/sunset and timezone helpers
+├── random_weather.py       # Random coordinate generator
+├── exceptions.py           # Custom exceptions
+├── requirements.txt
+├── Dockerfile
+├── favourites.db           # Auto-created on first run (not committed)
+└── .env                    # Not committed — create manually
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ emoji-country-flag==1.3.2
 # Logging
 loguru==0.7.3
 
+# Scheduler (daily subscriptions)
+apscheduler==3.10.4
+
 # Testing
 pytest==8.3.4
 pytest-asyncio==0.25.3

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,40 @@
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+scheduler = AsyncIOScheduler()
+
+
+def _job_id(user_id: int) -> str:
+    return f"sub_{user_id}"
+
+
+def add_or_replace_job(send_fn, sub: dict) -> None:
+    """Schedule or reschedule a daily weather job for one subscription."""
+    hour, minute = sub["send_time"].split(":")
+    try:
+        tz = pytz.timezone(sub["tz"])
+    except pytz.UnknownTimeZoneError:
+        tz = pytz.utc
+    scheduler.add_job(
+        send_fn,
+        trigger=CronTrigger(hour=int(hour), minute=int(minute), timezone=tz),
+        id=_job_id(sub["user_id"]),
+        args=[sub["user_id"], sub["city"]],
+        replace_existing=True,
+    )
+
+
+def remove_job(user_id: int) -> None:
+    """Remove a scheduled job if it exists."""
+    job_id = _job_id(user_id)
+    if scheduler.get_job(job_id):
+        scheduler.remove_job(job_id)
+
+
+def start(send_fn) -> None:
+    """Restore all saved subscriptions and start the scheduler."""
+    from subscriptions import get_all_subscriptions
+    for sub in get_all_subscriptions():
+        add_or_replace_job(send_fn, sub)
+    scheduler.start()

--- a/server.py
+++ b/server.py
@@ -12,8 +12,11 @@ from aiogram.enums import ContentType, ParseMode
 from aiogram.filters import Command
 from aiogram.types import InlineQueryResultArticle, InputTextMessageContent
 from loguru import logger
+from timezonefinder import TimezoneFinder
 
 import favourites as fav
+import scheduler as sched
+import subscriptions
 from exceptions import WrongInput
 from random_weather import generate_random_coords
 from timezoneutils import sun_condition, timezone
@@ -42,13 +45,16 @@ API_TOKEN = os.getenv("TELEGRAM_API_TOKEN")
 if not API_TOKEN:
     raise RuntimeError("TELEGRAM_API_TOKEN is not set — check your .env file")
 
-# Initialize SQLite database on startup
+# Initialize SQLite tables on startup
 fav.init_db()
+subscriptions.init_subscriptions_table()
 
 bot = Bot(token=API_TOKEN)
 dp = Dispatcher()
 router = Router()
 dp.include_router(router)
+
+_tf = TimezoneFinder()
 
 
 # ---------------------------------------------------------------------------
@@ -98,8 +104,45 @@ async def _send_city_weather(message: types.Message, city: str) -> None:
         raise WrongInput(f'City "{city}" is not defined')
 
 
+async def _send_subscription_weather(user_id: int, city: str) -> None:
+    """Called by the scheduler — sends daily weather directly to a user by ID."""
+    try:
+        response = get_openweather_city_response(city)
+        if response.get("cod") == ERROR:
+            logger.warning(f"Subscription: city '{city}' not found for user {user_id}")
+            return
+        coordinates = get_coordinates_by_city(response)
+        air_response = get_openweather_air_response(coordinates.latitude, coordinates.longitude)
+        air_quality = get_air_quality_type(air_response)
+        weather = get_weather(response)
+        sun_conds = sun_condition(
+            sunrise=time.mktime(weather.sunrise.timetuple()),
+            sunset=time.mktime(weather.sunset.timetuple()),
+            coordinates=coordinates,
+        )
+        area, local_time = timezone(coordinates)
+        weather_text = weather_repr_city(weather)
+        await bot.send_message(
+            user_id,
+            f"\u2600\ufe0f <b>Good morning! Daily weather for {city}</b>\n\n"
+            f"Time zone: {area}\n"
+            f"Local time: {local_time}\n"
+            f"Air Index Quality: {air_quality.value}\n"
+            f"{'*' * 10}\n"
+            f"{weather_text}"
+            f"{'*' * 10}\n"
+            f"\U0001f305: {sun_conds.sunrise.strftime('%H:%M')}\n"
+            f"\U0001f307: {sun_conds.sunset.strftime('%H:%M')}",
+            parse_mode=ParseMode.HTML,
+            reply_markup=_map_button(coordinates.latitude, coordinates.longitude),
+        )
+        await bot.send_location(user_id, latitude=coordinates.latitude, longitude=coordinates.longitude)
+    except Exception as e:
+        logger.error(f"Failed to send subscription weather to user {user_id}: {e}")
+
+
 # ---------------------------------------------------------------------------
-# Handlers
+# General handlers
 # ---------------------------------------------------------------------------
 
 @router.message(Command("start", "help"))
@@ -115,7 +158,11 @@ async def send_welcome(message: types.Message):
         "\u2764\ufe0f <b>Favourites</b>\n"
         "/save &lt;city&gt; \u2014 save a city (max 3)\n"
         "/my \u2014 show your saved cities\n"
-        "/remove &lt;city&gt; \u2014 remove a saved city",
+        "/remove &lt;city&gt; \u2014 remove a saved city\n\n"
+        "\u23f0 <b>Daily subscription</b>\n"
+        "/subscribe &lt;city&gt; &lt;HH:MM&gt; \u2014 get weather every day at a set time\n"
+        "/unsubscribe \u2014 cancel your subscription\n"
+        "/mysub \u2014 show your current subscription",
         parse_mode=ParseMode.HTML,
     )
 
@@ -253,12 +300,10 @@ async def save_city_command(message: types.Message):
         await message.answer("Please provide a city name:\n/save Stockholm")
         return
     city = parts[1].strip()
-    # Validate city exists on OpenWeather before saving
     response = get_openweather_city_response(city)
     if str(response.get("cod")) == ERROR:
         await message.answer("\u274c That city wasn't found. Check the spelling before saving.")
         return
-    # Use the canonical name returned by OpenWeather (correct capitalisation)
     canonical = response.get("name", city)
     status = fav.save_city(message.from_user.id, canonical)
     if status == "saved":
@@ -312,13 +357,95 @@ async def remove_city_command(message: types.Message):
 @logger.catch
 async def favourite_city_callback(callback: types.CallbackQuery):
     """Fetch and send weather when user taps a favourite city button."""
-    city = callback.data[4:]   # strip the 'fav:' prefix
+    city = callback.data[4:]
     await _send_city_weather(callback.message, city)
     await callback.answer()
 
 
 # ---------------------------------------------------------------------------
-# Catch-all city search (must stay last)
+# Daily subscription
+# ---------------------------------------------------------------------------
+
+@router.message(Command("subscribe"))
+@logger.catch
+async def subscribe_command(message: types.Message):
+    """Subscribe to a daily weather report for a city at a given local time."""
+    parts = message.text.split(maxsplit=2)
+    if len(parts) < 3:
+        await message.answer(
+            "Usage: /subscribe &lt;city&gt; &lt;HH:MM&gt;\n"
+            "Example: /subscribe Stockholm 08:00",
+            parse_mode=ParseMode.HTML,
+        )
+        return
+    city = parts[1].strip()
+    time_str = parts[2].strip()
+
+    # Validate time format
+    try:
+        hour_str, minute_str = time_str.split(":")
+        hour, minute = int(hour_str), int(minute_str)
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError
+    except (ValueError, AttributeError):
+        await message.answer("Invalid time. Use HH:MM format, e.g. 08:00")
+        return
+
+    # Validate city
+    response = get_openweather_city_response(city)
+    if str(response.get("cod")) == ERROR:
+        await message.answer("\u274c City not found. Check the spelling.")
+        return
+
+    canonical = response.get("name", city)
+    coords = get_coordinates_by_city(response)
+    tz_name = _tf.timezone_at(lat=coords.latitude, lng=coords.longitude) or "UTC"
+    send_time = f"{hour:02d}:{minute:02d}"
+
+    sub = dict(user_id=message.from_user.id, city=canonical, send_time=send_time, tz=tz_name)
+    subscriptions.save_subscription(**sub)
+    sched.add_or_replace_job(_send_subscription_weather, sub)
+
+    await message.answer(
+        f"\u23f0 Subscribed!\n"
+        f"You'll receive weather for <b>{canonical}</b> every day at "
+        f"<b>{send_time}</b> ({tz_name}).",
+        parse_mode=ParseMode.HTML,
+    )
+
+
+@router.message(Command("unsubscribe"))
+async def unsubscribe_command(message: types.Message):
+    """Cancel the user's daily weather subscription."""
+    removed = subscriptions.remove_subscription(message.from_user.id)
+    sched.remove_job(message.from_user.id)
+    if removed:
+        await message.answer("\u2705 Your daily subscription has been cancelled.")
+    else:
+        await message.answer("\u2139\ufe0f You don't have an active subscription.")
+
+
+@router.message(Command("mysub"))
+async def mysub_command(message: types.Message):
+    """Show the user's current subscription."""
+    sub = subscriptions.get_subscription(message.from_user.id)
+    if not sub:
+        await message.answer(
+            "You don't have an active subscription.\n"
+            "Use /subscribe &lt;city&gt; &lt;HH:MM&gt; to set one up.",
+            parse_mode=ParseMode.HTML,
+        )
+        return
+    await message.answer(
+        f"\u23f0 <b>Your daily subscription</b>\n"
+        f"City: <b>{sub['city']}</b>\n"
+        f"Time: <b>{sub['send_time']}</b> ({sub['tz']})",
+        parse_mode=ParseMode.HTML,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catch-all city search (must stay last among message handlers)
 # ---------------------------------------------------------------------------
 
 @router.message()
@@ -375,6 +502,7 @@ async def inline_weather(inline_query: types.InlineQuery):
 
 
 async def main():
+    sched.start(_send_subscription_weather)
     await dp.start_polling(bot)
 
 

--- a/server.py
+++ b/server.py
@@ -124,7 +124,7 @@ async def _send_subscription_weather(user_id: int, city: str) -> None:
         weather_text = weather_repr_city(weather)
         await bot.send_message(
             user_id,
-            f"\u2600\ufe0f <b>Good morning! Daily weather for {city}</b>\n\n"
+            f"\U0001f4cb <b>Cheers! Daily weather for {city}</b>\n\n"
             f"Time zone: {area}\n"
             f"Local time: {local_time}\n"
             f"Air Index Quality: {air_quality.value}\n"

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -1,0 +1,64 @@
+import sqlite3
+from pathlib import Path
+
+# Reuse the same database file as favourites
+DB_PATH = Path(__file__).parent / "favourites.db"
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_subscriptions_table() -> None:
+    """Create the subscriptions table if it doesn't already exist."""
+    with _connect() as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS subscriptions (
+                user_id   INTEGER PRIMARY KEY,
+                city      TEXT    NOT NULL,
+                send_time TEXT    NOT NULL,
+                tz        TEXT    NOT NULL
+            )
+        """)
+
+
+def save_subscription(user_id: int, city: str, send_time: str, tz: str) -> None:
+    """Insert or update a subscription for the user (one per user)."""
+    with _connect() as conn:
+        conn.execute("""
+            INSERT INTO subscriptions (user_id, city, send_time, tz)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
+                city      = excluded.city,
+                send_time = excluded.send_time,
+                tz        = excluded.tz
+        """, (user_id, city, send_time, tz))
+
+
+def get_subscription(user_id: int) -> dict | None:
+    """Return the user's subscription, or None if not subscribed."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM subscriptions WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def remove_subscription(user_id: int) -> bool:
+    """Remove a subscription. Returns True if it existed."""
+    with _connect() as conn:
+        cursor = conn.execute(
+            "DELETE FROM subscriptions WHERE user_id = ?",
+            (user_id,),
+        )
+    return cursor.rowcount > 0
+
+
+def get_all_subscriptions() -> list[dict]:
+    """Return all subscriptions — used at bot startup to restore scheduled jobs."""
+    with _connect() as conn:
+        rows = conn.execute("SELECT * FROM subscriptions").fetchall()
+    return [dict(row) for row in rows]


### PR DESCRIPTION
## Summary
Adds per-user daily weather subscriptions with timezone-aware scheduling, plus a full README rewrite.

## New files

### `subscriptions.py`
SQLite CRUD layer (reuses `favourites.db`):
- `init_subscriptions_table()` — creates table on startup
- `save_subscription(user_id, city, send_time, tz)` — insert or update (one subscription per user)
- `get_subscription(user_id)` — returns the subscription or None
- `remove_subscription(user_id)` — deletes it
- `get_all_subscriptions()` — used at startup to restore all scheduled jobs

### `scheduler.py`
APScheduler wrapper:
- `start(send_fn)` — restores all subscriptions from DB and starts the scheduler
- `add_or_replace_job(send_fn, sub)` — schedules a cron job at the user's local time
- `remove_job(user_id)` — cancels a job

## New commands
| Command | Behaviour |
|---|---|
| `/subscribe Stockholm 08:00` | Validates city, detects timezone from coordinates, saves + schedules |
| `/unsubscribe` | Cancels subscription and removes the job |
| `/mysub` | Shows city, time and timezone |

## Other changes
- `server.py`: added `_send_subscription_weather(user_id, city)` — sends weather directly to a user via `bot.send_message` (no `message` object needed)
- `requirements.txt`: added `apscheduler==3.10.4`
- `README.md`: full rewrite with features, commands table, setup guide, Docker instructions, project structure

## How to test
1. `pip install apscheduler==3.10.4` then `python server.py`
2. `/subscribe Stockholm 08:00` → confirm with city + timezone in reply
3. `/mysub` → shows the subscription
4. `/subscribe Moscow 09:00` → replaces the previous one
5. `/unsubscribe` → cancels
6. `/mysub` → says no active subscription
7. To test delivery without waiting until morning: `/subscribe <your_city> <current_time + 1 min>`
